### PR TITLE
Add JumpStack instruction

### DIFF
--- a/src/output/verifier.rs
+++ b/src/output/verifier.rs
@@ -525,6 +525,7 @@ impl<'a, 'b, 'c> Verifier<'a, 'b, 'c> {
             Opcode::Sidx => &[&[]],
             Opcode::Bfa => &[&[OperandType::String, OperandType::Int32, OperandType::Label]],
             Opcode::Jmp => &[&[OperandType::String, OperandType::Int32, OperandType::Label]],
+            Opcode::Jmps => &[&[]],
             Opcode::Add => &[&[]],
             Opcode::Sub => &[&[]],
             Opcode::Mul => &[&[]],


### PR DESCRIPTION
Adds the new [JumpStack](https://github.com/KSP-KOS/KOS/blob/8f281a459b6ea0ba917c91bbbc117e68bb948199/src/kOS.Safe/Compilation/Opcode.cs#L1129) instruction to kasm.